### PR TITLE
do not write a cache entry if there is no cache key

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -293,7 +293,7 @@ class Downloader
         }
 
         $response = new Response($data, $lastHeaders);
-        if ($response->getHeader('last-modified')) {
+        if ($response->getHeader('last-modified') && $cacheKey) {
             $this->cache->write($cacheKey, json_encode($response));
         }
 


### PR DESCRIPTION
Writing to the cache with an empty key will fail with "failed to open stream: Is a directory", so do not try to do that.

This caused a small fallout on our CI system since, for some reason, Cloudflare or the backend service responds with a "last-modified" header for our CI systems (AWS) but not for our local kits, so this error was quite hard to track down. 

I hope this is the correct place to fix it, but from what I see, CI bug or not, this code should not try to write a cache with am empty key, correct?

Here is how a `composer install` failed for us (because of this?): 
```
  [ErrorException]                                                                                              
  file_put_contents(/tmp/composer/cache/repo/https---flex.symfony.com/): failed to open stream: Is a directory  
```